### PR TITLE
Add .ruby-gemset file to compliment .ruby-version

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+common-standards-project


### PR DESCRIPTION
So that when I `bundle install`, the libs get sandboxed. 
