### PR TITLE
Hash keys are strings

### DIFF
--- a/importer/cli
+++ b/importer/cli
@@ -17,7 +17,7 @@ class ImporterCLI < Thor
     end
 
     # create the sample user
-    user = $db[:users].find({apiKey => "vZKoJwFB1PTJnozKBSANADc3"}).to_a.first
+    user = $db[:users].find({"apiKey" => "vZKoJwFB1PTJnozKBSANADc3"}).to_a.first
     if user.nil?
       $db[:users].insert_one({
         _id:     SecureRandom.uuid().to_s.upcase.gsub('-', ''),


### PR DESCRIPTION
Fixes issue where:

$ ./importer/cli setup
D, [2015-12-19T17:37:11.928138 #26864] DEBUG -- : MONGODB | Adding 127.0.0.1:27017 to the cluster. | runtime: 0.0079ms
D, [2015-12-19T17:37:11.929493 #26864] DEBUG -- : MONGODB | COMMAND | namespace=admin.$cmd selector={:ismaster=>1} flags=[] limit=-1 skip=0 project=nil | runtime: 1.2133ms
./importer/cli:20:in `setup': undefined local variable or method`apiKey' for #ImporterCLI:0x007fad7a041030 (NameError)
    from /Users/jordan/.rvm/gems/ruby-2.2.2@common-standards-project/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/jordan/.rvm/gems/ruby-2.2.2@common-standards-project/gems/thor-0.19.1/lib/thor/invocation.rb:126:in`invoke_command'
    from /Users/jordan/.rvm/gems/ruby-2.2.2@common-standards-project/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/jordan/.rvm/gems/ruby-2.2.2@common-standards-project/gems/thor-0.19.1/lib/thor/base.rb:440:in`start'
    from ./importer/cli:46:in `<main>'
