### PR TITLE
Install ztsd-ruby to support MongoDB zstd compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'oj'
 gem 'mongo', '~>2.19.3'
 gem 'bson'
 gem 'bson_ext'
+gem 'zstd-ruby'
 # gem 'grape'
 gem 'grape', '~>0.16.0'
 # for this issue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     virtus_convert (0.1.0)
     zeitwerk (2.4.2)
+    zstd-ruby (1.5.6.6)
 
 PLATFORMS
   ruby
@@ -278,6 +279,7 @@ DEPENDENCIES
   typhoeus
   virtus (~> 1.0.5)
   virtus_convert
+  zstd-ruby
 
 RUBY VERSION
    ruby 2.7.4p191


### PR DESCRIPTION
Ref: https://www.mongodb.com/docs/ruby-driver/current/reference/create-client/#compression

Then one can add `compressors=zstd` to the connection string, to enable zstd compression.

Tested locally; the DB client started succesfully.