### PR TITLE
fix: Update certs and openssl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM circleci/ruby:2.7.4
 RUN sudo apt-get update && sudo apt-get install libjemalloc2 && sudo rm -rf /var/lib/apt/lists/*
 ENV LD_PRELOAD=libjemalloc.so.2
 
+# Ensure certs and openssl are up-to-date
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  openssl \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /home/app
 
 ENV PORT 3000


### PR DESCRIPTION
This is Claude's best guess for a fix (and matches my intuition).

Our base Docker image is 4 years old; it's likely that some of the root certs shipped with its OS have expired and we don't have the new versions, causing TLS connections to fail.

It would be nice to upgrade the base image instead, but I did not see any newer ones from the same publisher, and we may run into Ruby version incompatibilities for anything too new.

I don't know how to test this outside of prod.